### PR TITLE
added environment variable to disable DNS entry in wireguard conf

### DIFF
--- a/cmd/subspace/handlers.go
+++ b/cmd/subspace/handlers.go
@@ -18,10 +18,10 @@ import (
 )
 
 var (
-	validEmail         = regexp.MustCompile(`^[ -~]+@[ -~]+$`)
-	validPassword      = regexp.MustCompile(`^[ -~]{6,200}$`)
-	validString        = regexp.MustCompile(`^[ -~]{1,200}$`)
-	maxProfiles        = 250
+	validEmail    = regexp.MustCompile(`^[ -~]+@[ -~]+$`)
+	validPassword = regexp.MustCompile(`^[ -~]{6,200}$`)
+	validString   = regexp.MustCompile(`^[ -~]{1,200}$`)
+	maxProfiles   = 250
 )
 
 func getEnv(key, fallback string) string {
@@ -423,6 +423,10 @@ func profileAddHandler(w *Web) {
 	if gw := getEnv("SUBSPACE_IPV6_GW", "nil"); gw != "nil" {
 		ipv6Gw = gw
 	}
+	disableDNS := ""
+	if gw := getEnv("SUBSPACE_DISABLE_DNS", "nil"); gw == "true" {
+		disableDNS = "# "
+	}
 	ipv6Cidr := "64"
 	if cidr := getEnv("SUBSPACE_IPV6_CIDR", "nil"); cidr != "nil" {
 		ipv6Cidr = cidr
@@ -456,7 +460,7 @@ WGPEER
 cat <<WGCLIENT >clients/{{$.Profile.ID}}.conf
 [Interface]
 PrivateKey = ${wg_private_key}
-DNS = {{$.IPv4Gw}}, {{$.IPv6Gw}}
+{{$.DisableDNS}}DNS = {{$.IPv4Gw}}, {{$.IPv6Gw}}
 Address = {{$.IPv4Pref}}{{$.Profile.Number}}/{{$.IPv4Cidr}},{{$.IPv6Pref}}{{$.Profile.Number}}/{{$.IPv6Cidr}}
 
 [Peer]
@@ -476,6 +480,7 @@ WGCLIENT
 		IPv6Pref     string
 		IPv4Cidr     string
 		IPv6Cidr     string
+		DisableDNS   string
 		Listenport   string
 		AllowedIPS   string
 	}{
@@ -488,6 +493,7 @@ WGCLIENT
 		ipv6Pref,
 		ipv4Cidr,
 		ipv6Cidr,
+		disableDNS,
 		listenport,
 		allowedips,
 	})

--- a/cmd/subspace/handlers.go
+++ b/cmd/subspace/handlers.go
@@ -424,7 +424,7 @@ func profileAddHandler(w *Web) {
 		ipv6Gw = gw
 	}
 	disableDNS := ""
-	if shouldDisableDNS := getEnv("SUBSPACE_DISABLE_DNS", "nil"); shouldDisableDNS == "true" {
+	if shouldDisableDNS := getEnv("SUBSPACE_DISABLE_DNS", "nil"); shouldDisableDNS != "nil" {
 		disableDNS = "# "
 	}
 	ipv6Cidr := "64"

--- a/cmd/subspace/handlers.go
+++ b/cmd/subspace/handlers.go
@@ -424,7 +424,7 @@ func profileAddHandler(w *Web) {
 		ipv6Gw = gw
 	}
 	disableDNS := ""
-	if gw := getEnv("SUBSPACE_DISABLE_DNS", "nil"); gw == "true" {
+	if shouldDisableDNS := getEnv("SUBSPACE_DISABLE_DNS", "nil"); shouldDisableDNS == "true" {
 		disableDNS = "# "
 	}
 	ipv6Cidr := "64"


### PR DESCRIPTION
## Background

To avoid wrong regional DNS resolution, which would cause international users to try to connect to the wrong servers when using the DNS provided by subspace, an option should exist to disable the DNS entry in wireguard conf.

### Changes

* added env var `SUBSPACE_DISABLE_DNS` which, when `true`, causes new config files to be created with the DNS entry commented out.


## Testing

Create a new subspace instance with `SUBSPACE_DISABLE_DNS=true`, create a new config file, check if `DNS =` in wg0.conf is commented out:

```conf
[Interface]
PrivateKey = {REDACTED}
# DNS = 10.99.97.1, fd00::10:97:1
Address = 10.99.97.2/24,fd00::10:97:2/64

[Peer]
PublicKey = XIvA8kM+O9M+FGgR1SvkCv2DDrxWah+wp10tRfYAVzU=

Endpoint = {REDACTED}:51820
AllowedIPs = 0.0.0.0/0, ::/0
```


