### PR TITLE
use self-hosted runners to avoid running out of minutes

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   update_release_draft:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: release-drafter/release-drafter@v5
         env:


### PR DESCRIPTION
This pull request was automated with waycarbon/github-repos/replace_all_code_occurrences_in_github.py